### PR TITLE
fix(nested-filter):  results.remove is not a function

### DIFF
--- a/nested-filter.js
+++ b/nested-filter.js
@@ -114,7 +114,7 @@ function afterRemoteFind(ctx, options, next) {
     if (originalFilter.skip) {
       results.remove(0, originalFilter.skip - 1);
     }
-    if (originalFilter.limit && results.length > originalFilter.limit) {
+    if (results.remove && originalFilter.limit && results.length > originalFilter.limit) {
       results.remove(originalFilter.limit, results.length - 1);
     }
 


### PR DESCRIPTION
When using limit on 'filter' and the return is greater than the limit, the component returns `TypeError: results.remove is not a function`.